### PR TITLE
ADDED passive/active voice and POS tagger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ interviewer_removed/
 samples.txt
 .DS_Store
 __pycache__/
+
+POS_PA_tagger/stanford_NLP
+POS_PA_tagger/transcripts
+POS_PA_tagger/PA_output
+POS_PA_tagger/POS_output

--- a/extractor/POS_tagger.py
+++ b/extractor/POS_tagger.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+import os, requests, re
+import csv
+import pandas as pd
+from nltk import word_tokenize
+from nltk import sent_tokenize
+from nltk.parse.stanford import StanfordParser
+from nltk.parse.stanford import StanfordDependencyParser
+from nltk.tag.stanford import StanfordPOSTagger
+from text_locations import transcripts
+
+
+java_path = "usr/bin/java"
+os.environ['JAVAHOME'] = java_path
+current_dir = os.path.dirname(os.path.abspath(__file__))
+
+stanford_parser_dir = current_dir + '/stanford_NLP/stanford-postagger-full-2015-04-20'
+path_to_model = stanford_parser_dir + "/models/english-bidirectional-distsim.tagger"
+path_to_jar = stanford_parser_dir + "/stanford-postagger.jar"
+tagger=StanfordPOSTagger(path_to_model, path_to_jar)
+
+POS_TAGS = ["CC", "CD", "DT", "EX", "FW", "IN", "JJ", "JJR", "JJS", "LS", "MD", "NN", "NNS", "NNP", "NNPS", "PDT", "POS", "PRP", "PRP$", "RB", "RBR", "RBS", "RP", "SYM", "TO", "UH", "VB", "VBD", "VBG", "VBN", "VBP", "VBZ", "WDT", "WP", "WP$", "WRB"] 
+
+# Save document from dataframe to CSV
+def save_csv_file(document_df, database_location):
+    cols = list(document_df.columns.values)
+    cols.insert(0, cols.pop())
+    cols.insert(0, cols.pop())
+
+    document_df = document_df[cols]
+    with open(database_location , 'w', newline='', encoding='utf-8') as csvFile:
+        document_df.to_csv(csvFile, sep=',', index=False)
+
+def parse_sentence(sentence):
+    sentence = sentence.strip('\n')
+    sentence = sentence.strip('\t')
+    tagsInSentence = set()
+    sentence_data = {}
+    sentence_data["sentence"] = sentence
+    # Setting higher memory limit for long sentences
+    tagger.java_options='-mx4096m'
+    for tags in POS_TAGS:
+        sentence_data[tags] = []
+    for word, tag in tagger.tag(sentence.split()):
+        if tag in sentence_data:
+            sentence_data[tag].append(word)
+            tagsInSentence.add(tag)
+
+    sentence_data["tags"] = tagsInSentence
+    
+    return  sentence_data         
+
+def extract_sentences(page_content):
+    this_text_data = []
+    sentences_to_parse = sent_tokenize(page_content)
+    for sentence in sentences_to_parse:
+        new_data_row = parse_sentence(sentence)
+        this_text_data.append(new_data_row)
+    document_df = pd.DataFrame(this_text_data)
+
+    return document_df
+
+
+def get_text_from_dir(location):
+    with open(location, 'r') as local_file:
+        file_content = local_file.read()
+        return file_content
+
+
+def run_prog(dictionary_array):
+    print(dictionary_array)
+    for dictionary in dictionary_array:
+        print ('Processing ' +  dictionary['location'] )
+        text = get_text_from_dir(dictionary['location'])
+        sentences_data = extract_sentences(text)
+
+        save_csv_file(sentences_data, 'POS_output' + dictionary['results'])
+
+
+run_prog(transcripts)

--- a/extractor/load_csv.py
+++ b/extractor/load_csv.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from text_locations import transcripts
+
+def generateDataframe(file):
+    df = pd.read_csv(file,encoding='utf-8')
+    print(df)
+
+def run_prog(dictionary_array):
+    for dictionary in dictionary_array: 
+        # Load Passive - Active CSV files
+        # generateDataframe('PA_output' + dictionary['results'])
+
+        # Load Part of Speech CSV files
+        generateDataframe('POS_output' + dictionary['results'])
+
+run_prog(transcripts)

--- a/extractor/passive_active_tagger.py
+++ b/extractor/passive_active_tagger.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+import os, requests, re, csv
+import pandas as pd
+from nltk import word_tokenize
+from nltk import sent_tokenize
+from nltk.parse.stanford import StanfordParser
+from nltk.parse.stanford import StanfordDependencyParser
+from text_locations import transcripts
+
+java_path = "usr/bin/java"
+os.environ['JAVAHOME'] = java_path
+current_dir = os.path.dirname(os.path.abspath(__file__))
+
+stanford_parser_dir = current_dir + '/stanford_NLP/stanford-parser-full-2015-04-20'
+eng_model_path = stanford_parser_dir + "/edu/stanford/nlp/models/lexparser/englishRNN.ser.gz"
+my_path_to_models_jar = stanford_parser_dir + "/stanford-parser-3.5.2-models.jar"
+my_path_to_jar = stanford_parser_dir + "/stanford-parser.jar"
+
+parser = StanfordParser(model_path = eng_model_path, path_to_models_jar = my_path_to_models_jar, path_to_jar = my_path_to_jar)
+dependency_parser = StanfordDependencyParser(path_to_jar = my_path_to_jar, path_to_models_jar = my_path_to_models_jar)
+
+
+def save_csv_file(this_text_data, database_location):
+    with open(database_location , 'w', newline='', encoding='utf-8') as csvFile:
+        csvWriter = csv.writer(csvFile, delimiter = ',')
+        for n in range(0, len(this_text_data)):
+            csvWriter.writerow(this_text_data[n])
+
+def parse_sentence(sentence):
+    print (sentence)
+    result = dependency_parser.raw_parse(sentence)
+    dep = result.__next__()
+    parsed_result = list(dep.triples())
+    print (parsed_result)
+    auxpass = False
+    nsubjpass = False
+    nsubj = False
+
+    if "nsubj" in str(parsed_result):
+       nsubj = True
+
+    if "nsubjpass" in str(parsed_result):
+       nsubjpass = True
+
+    if "auxpass" in str(parsed_result):
+        auxpass = True
+
+    words_in_sentence = word_tokenize(sentence)
+    sentence_length_in_words = len(words_in_sentence)
+    longest_word = max(words_in_sentence, key=len)
+    longest_word_length = len(longest_word)
+    return [sentence,nsubj,nsubjpass,auxpass,sentence_length_in_words,longest_word,longest_word_length]
+
+def extract_sentences(page_content):
+    this_text_data = []
+    this_text_data.append(['sentence','nsubj','nsubjpass','auxpass','sentence_length_in_words','longest_word','longest_word_length'])
+    sentences_to_parse = sent_tokenize(page_content)
+    for sentence in sentences_to_parse:
+        new_data_row = parse_sentence(sentence)
+        this_text_data.append(new_data_row)
+    return this_text_data
+
+
+def get_text_from_dir(location):
+    with open(location, 'r') as local_file:
+        file_content = local_file.read()
+        return file_content
+
+def run_prog(dictionary_array):
+    print(dictionary_array)
+    for dictionary in dictionary_array:
+        print ('Processing ' +  dictionary['location'] )
+        text = get_text_from_dir(dictionary['location'])
+        sentences_data = extract_sentences(text)
+
+        save_csv_file(sentences_data,'PA_output' + dictionary['results'])
+
+
+run_prog(transcripts)

--- a/extractor/text_locations.py
+++ b/extractor/text_locations.py
@@ -1,0 +1,92 @@
+transcripts = [
+	{
+		'location': 'transcripts/samples.txt',
+		'results': '/samples.csv'
+	},
+	{
+		'location': 'transcripts/Alyssa_Katz_transcript_IR.txt',
+		'results': '/Alyssa_Katz_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Arnold_interview_IR.txt',
+		'results': '/Arnold_interview_IR.csv'
+	},
+	{
+		'location': 'transcripts/Bettina_Diamani_transcript_IR.txt',
+		'results': '/Bettina_Diamani_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Cap_Daddy_transcript_IR.txt',
+		'results': '/Cap_Daddy_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Charles_Barron_transcript_IR.txt',
+		'results': '/Charles_Barron_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Clinton_Miller_transcript_IR.txt',
+		'results': '/Clinton_Miller_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Customer_at_Jacks_barbershop_transcript_IR.txt',
+		'results': '/Customer_at_Jacks_barbershop_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Dan_Steinberg_Interview_IR.txt',
+		'results': '/Dan_Steinberg_Interview_IR.csv'
+	},
+	{
+		'location': 'transcripts/Deborah_Tillman_transcript_IR.txt',
+		'results': '/Deborah_Tillman_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Dezo_transcript_IR.txt',
+		'results': '/Dezo_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Joe_at_Music_Factory_IR.txt',
+		'results': '/Joe_at_Music_Factory_IR.csv'
+	},
+	{
+		'location': 'transcripts/Maisha_Morales_Transcript_IR.txt',
+		'results': '/Maisha_Morales_Transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Michelle_de_le_uz_transcript_IR.txt',
+		'results': '/Michelle_de_le_uz_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Neil_Smith_transcript_IR.txt',
+		'results': '/Neil_Smith_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Purnima_Kapur_transcript_IR.txt',
+		'results': '/Purnima_Kapur_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Rahsun_Houston_FM_2006_IR.txt',
+		'results': '/Rahsun_Houston_FM_2006_IR.csv'
+	},
+	{
+		'location': 'transcripts/Randy_and_Beverly_transcript_IR.txt',
+		'results': '/Randy_and_Beverly_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Ron_Shiffman_transcript_IR.txt',
+		'results': '/Ron_Shiffman_transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Scherille_Murray_Interview_IR.txt',
+		'results': '/Scherille_Murray_Interview_IR.csv'
+	},
+	{
+		'location': 'transcripts/Stacey Sutton transcript_IR.txt',
+		'results': '/Stacey Sutton transcript_IR.csv'
+	},
+	{
+		'location': 'transcripts/Wilder_interview_transcript_IR.txt',
+		'results': '/Wilder_interview_transcript_IR.csv'
+	}
+]
+
+	


### PR DESCRIPTION
**text_locations.py** : Array of dictionaries that contains the locations of files in the corpus and where corresponding data about them is located. 

**POS_tagger.py** :  Uses StanfordNLP library to implement part of speech tagging to each sentence in a file. Data is stored into a dataframe and then saved as a CSV file in _POS_output_ directory.

**passive_active_tagger.py**  : Uses StanfordNLP library to find if the relationships 'nsubj', 'nsubjpass' or 'auxpass' exists in file. These relationships help us determine if sentence is using passive or active voice. 


